### PR TITLE
feat: install gh cli if not present in runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This repository has been forked from https://github.com/PierreRAFFA/cancel-previous-runs-action ⚠️
+
 # Cancel Previous Runs Action 
 
 This GitHub action is responsible to cancel any previous runs for the current workflow or from a given list.  

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,10 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: "Install the gh cli tool if not installed"
+    shell: bash
+    run: ${{ github.action_path }}/deps.sh
+
   - name: Cancel
     shell: bash
     run: ${GITHUB_ACTION_PATH}/cancel.sh

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: "Install the gh cli tool if not installed"
+  - name: "Install gh cli if not already installed"
     shell: bash
     run: ${{ github.action_path }}/deps.sh
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: 'Cancel Previous Runs Action'
+name: 'Cancel Any Previous Run'
 description: 'Responsible to cancel previous runs for the current workflow or from a given list. Events (merge_group, pull_request, push)'
 branding:
   icon: 'alert-octagon'

--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ runs:
   steps:
   - name: "Install gh cli if not already installed"
     shell: bash
-    run: ${{ github.action_path }}/deps.sh
+    run: ${GITHUB_ACTION_PATH}/deps.sh
 
   - name: Cancel
     shell: bash

--- a/deps.sh
+++ b/deps.sh
@@ -6,7 +6,7 @@ if [ -x "$(command -v gh)" ]; then
     exit 0
 fi
 
-version=${GH_CLI_VERSION:-2.8.0}
+version=${GH_CLI_VERSION:-2.47.0}
 echo "Installing gh cli in version: $version"
 
 machine=$(uname -m)

--- a/deps.sh
+++ b/deps.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# check if gh binary is available
+if [ -x "$(command -v gh)" ]; then
+    echo 'gh cli is installed.'
+    exit 0
+fi
+
+version=${GH_CLI_VERSION:-2.8.0}
+echo "Installing gh cli in version: $version"
+
+machine=$(uname -m)
+case $machine in
+    aarch64)
+        arch="arm64"
+        ;;
+    x86_64)
+        arch="amd64"
+        ;;
+    *)
+        echo "Unsupported architecture: $machine"
+        exit 1
+        ;;
+esac
+
+wget https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_${arch}.tar.gz
+tar -xvf gh_${version}_linux_${arch}.tar.gz
+sudo cp $(pwd)/gh_${version}_linux_${arch}/bin/gh /usr/local/bin/


### PR DESCRIPTION
**Context**

This PR installs `gh` when the action is used on a runner that does not contains `gh`. This is useful in cases where self-hosted runners are used and it allows the action to be "plug-and-play".

**How is it done?**

First, it checks if `gh` command is available. If yes, then it proceed with normal action flow. If not, then it will download the most recent `gh` version from today [(v2.47.0)](https://github.com/cli/cli/releases/tag/v2.47.0) and install it.

You can also set env var `GH_CLI_VERSION` to choose a GH_CLI specific version.